### PR TITLE
Docker Compose v1/v2 detection in db.sh + new app.sh lifecycle script

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
       "Bash(ls /home/raseel/code/s3-browser/graphify-out/ 2>/dev/null || mkdir -p /home/raseel/code/s3-browser/graphify-out)",
       "WebFetch(domain:www.avanse.com)",
       "WebSearch",
-      "Bash(curl -sL --max-time 25 -A \"Mozilla/5.0\" https://www.avanse.com/ -o avanse.html)"
+      "Bash(curl -sL --max-time 25 -A \"Mozilla/5.0\" https://www.avanse.com/ -o avanse.html)",
+      "Bash(git checkout *)"
     ],
     "additionalDirectories": [
       "/home/raseel/code/s3-browser/graphify-out"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,12 @@ npm run typecheck    # tsc --noEmit
 
 npm run generate-keys # generate ENCRYPTION_KEY / secrets for .env
 
+# App lifecycle (PM2 + database, wraps db.sh)
+./app.sh setup [prod|dev]   # install + db setup + build + start (mode defaults to prod)
+./app.sh start|stop|restart|status|logs|build|migrate|seed|reset|purge [prod|dev]
+# prod = `next start` on 3000 (PM2 name "s3-browser")
+# dev  = `next dev` on 5000 (PM2 name "s3-browser-dev"); PORT env overrides either
+
 # Database (wraps docker-compose.db.yml: Postgres 16 + pgAdmin)
 ./db.sh setup        # start db + run migrations + seed (first-time setup)
 ./db.sh start|stop|status|logs|backup|restore|reset

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ npm run build
 pm2 start npm --name "s3-browser" -- run start
 ```
 
+Or let `app.sh` handle the database and PM2 together:
+```bash
+./app.sh setup        # install + database + build + start (prod, port 3000)
+./app.sh start dev    # development mode on port 5000
+./app.sh status       # PM2 + database status
+./app.sh stop         # stop app and database
+./app.sh purge        # remove PM2 process, database data, .next, node_modules
+```
+
 Open [http://localhost:5000](http://localhost:5000)
 
 **Default login:** `admin` / `admin` (you'll be forced to change password)

--- a/app.sh
+++ b/app.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+# Application management script for S3 Browser
+#
+# Manages the Next.js app under PM2 plus its PostgreSQL database (delegated
+# to ./db.sh, which owns all Docker Compose handling).
+#
+# Modes:
+#   prod (default) - `next start` on port 3000, PM2 process "s3-browser"
+#   dev            - `next dev`   on port 5000, PM2 process "s3-browser-dev"
+
+set -e
+
+cd "$(dirname "$0")"
+
+DB_SCRIPT="./db.sh"
+
+if [ ! -x "$DB_SCRIPT" ]; then
+  echo "❌ $DB_SCRIPT not found or not executable (expected alongside app.sh)."
+  exit 1
+fi
+
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "❌ PM2 not found. Install it with: npm install -g pm2"
+  exit 1
+fi
+
+COMMAND="$1"
+MODE="${2:-${MODE:-prod}}"
+
+case "$MODE" in
+  prod)
+    APP_NAME="s3-browser"
+    APP_PORT="${PORT:-3000}"
+    # next start reads PORT from the environment.
+    PM2_START=(pm2 start npm --name "$APP_NAME" -- run start)
+    ;;
+  dev)
+    APP_NAME="s3-browser-dev"
+    APP_PORT="${PORT:-5000}"
+    # npm run dev pins -p 5000, so invoke next directly to honour PORT.
+    PM2_START=(pm2 start npx --name "$APP_NAME" -- next dev -p "$APP_PORT" --hostname 0.0.0.0)
+    ;;
+  *)
+    echo "❌ Unknown mode: $MODE (expected 'prod' or 'dev')"
+    exit 1
+    ;;
+esac
+
+app_is_running() {
+  pm2 describe "$APP_NAME" >/dev/null 2>&1
+}
+
+require_env_file() {
+  if [ ! -f .env ]; then
+    echo "❌ No .env file found. Copy .env.example to .env and fill it in"
+    echo "   (run 'npm run generate-keys' for ENCRYPTION_KEY / NEXTAUTH_SECRET)."
+    exit 1
+  fi
+}
+
+build_app() {
+  echo "🏗️  Building the application..."
+  npm run build
+}
+
+start_app() {
+  require_env_file
+
+  if [ "$MODE" = "prod" ] && [ ! -d .next ]; then
+    echo "ℹ️  No build found."
+    build_app
+    echo ""
+  fi
+
+  if app_is_running; then
+    echo "🔄 Restarting PM2 process '$APP_NAME'..."
+    PORT="$APP_PORT" pm2 restart "$APP_NAME" --update-env
+  else
+    echo "🚀 Starting PM2 process '$APP_NAME' ($MODE mode, port $APP_PORT)..."
+    PORT="$APP_PORT" "${PM2_START[@]}"
+  fi
+
+  echo "✅ Application running: http://localhost:$APP_PORT"
+}
+
+stop_app() {
+  if app_is_running; then
+    echo "🛑 Stopping PM2 process '$APP_NAME'..."
+    pm2 stop "$APP_NAME"
+    echo "✅ Application stopped"
+  else
+    echo "ℹ️  PM2 process '$APP_NAME' is not registered — nothing to stop"
+  fi
+}
+
+delete_app() {
+  if app_is_running; then
+    echo "🗑️  Removing PM2 process '$APP_NAME'..."
+    pm2 delete "$APP_NAME"
+  fi
+}
+
+case "$COMMAND" in
+  setup)
+    require_env_file
+    echo "🏗️  Setting up S3 Browser ($MODE mode)..."
+    echo ""
+    echo "1️⃣  Installing dependencies..."
+    npm install
+    echo ""
+    echo "2️⃣  Setting up the database..."
+    "$DB_SCRIPT" setup
+    echo ""
+    if [ "$MODE" = "prod" ]; then
+      echo "3️⃣  Building the application..."
+      build_app
+      echo ""
+    fi
+    echo "4️⃣  Starting the application..."
+    start_app
+    echo ""
+    echo "✅ Setup completed!"
+    ;;
+
+  start)
+    echo "1️⃣  Starting the database..."
+    "$DB_SCRIPT" start
+    echo ""
+    echo "2️⃣  Starting the application..."
+    start_app
+    ;;
+
+  stop)
+    stop_app
+    echo ""
+    "$DB_SCRIPT" stop
+    ;;
+
+  restart)
+    echo "🔄 Restarting S3 Browser ($MODE mode)..."
+    "$DB_SCRIPT" start
+    start_app
+    ;;
+
+  build)
+    build_app
+    echo "✅ Build completed"
+    ;;
+
+  status)
+    echo "📦 Application (PM2):"
+    pm2 list
+    echo ""
+    echo "🗄️  Database:"
+    "$DB_SCRIPT" status
+    ;;
+
+  logs)
+    pm2 logs "$APP_NAME"
+    ;;
+
+  migrate)
+    "$DB_SCRIPT" migrate
+    ;;
+
+  seed)
+    "$DB_SCRIPT" seed
+    ;;
+
+  reset)
+    stop_app
+    echo ""
+    "$DB_SCRIPT" reset
+    echo ""
+    echo "ℹ️  Run './app.sh start $MODE' to bring the application back up."
+    ;;
+
+  purge)
+    echo "⚠️  WARNING: This will permanently remove:"
+    echo "     - the PM2 process '$APP_NAME'"
+    echo "     - the database containers AND all data volumes"
+    echo "     - the .next build directory"
+    echo "     - node_modules"
+    echo ""
+    read -p "Type 'purge' to confirm: " confirm
+    if [ "$confirm" != "purge" ]; then
+      echo "❌ Cancelled"
+      exit 0
+    fi
+
+    delete_app
+    echo ""
+    echo "🗄️  Destroying the database..."
+    printf 'yes\n' | "$DB_SCRIPT" destroy
+    echo ""
+    echo "🧹 Removing build artifacts and dependencies..."
+    rm -rf .next node_modules
+    echo ""
+    echo "✅ Purge completed. Run './app.sh setup' to rebuild from scratch."
+    ;;
+
+  *)
+    echo "S3 Browser - Application Management"
+    echo ""
+    echo "Usage: ./app.sh <command> [mode]"
+    echo ""
+    echo "Modes:"
+    echo "  prod        - next start on port 3000 (default)"
+    echo "  dev         - next dev on port 5000"
+    echo ""
+    echo "Commands:"
+    echo "  setup       - First-time setup (install + database + build + start)"
+    echo "  start       - Start the database and the application"
+    echo "  stop        - Stop the application and the database"
+    echo "  restart     - Restart the application (ensures the database is up)"
+    echo "  build       - Build the application only"
+    echo "  status      - Show PM2 and database status"
+    echo "  logs        - Tail application logs"
+    echo "  migrate     - Run database migrations"
+    echo "  seed        - Seed initial data"
+    echo "  reset       - Stop the app and reset the database"
+    echo "  purge       - Remove PM2 process, database data, .next and node_modules"
+    echo ""
+    echo "Examples:"
+    echo "  ./app.sh setup             # First-time production setup"
+    echo "  ./app.sh start dev         # Start in development mode on port 5000"
+    echo "  ./app.sh logs              # Tail production logs"
+    echo "  PORT=8080 ./app.sh start   # Override the port"
+    echo ""
+    echo "Database-only operations live in ./db.sh"
+    ;;
+esac

--- a/db.sh
+++ b/db.sh
@@ -6,10 +6,27 @@ set -e
 
 COMPOSE_FILE="docker-compose.db.yml"
 
+# Detect which Docker Compose flavour is available:
+#   - Compose v2 plugin:  docker compose
+#   - Legacy v1 binary:   docker-compose
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo "❌ Neither 'docker compose' (v2 plugin) nor 'docker-compose' (v1) was found."
+  echo "   Install Docker Compose and try again: https://docs.docker.com/compose/install/"
+  exit 1
+fi
+
+compose() {
+  "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" "$@"
+}
+
 case "$1" in
   start)
     echo "🚀 Starting PostgreSQL + pgAdmin..."
-    docker-compose -f $COMPOSE_FILE up -d
+    compose up -d
     echo "✅ Database services started"
     echo ""
     echo "📊 PostgreSQL: localhost:5432"
@@ -22,19 +39,19 @@ case "$1" in
   
   stop)
     echo "🛑 Stopping database services..."
-    docker-compose -f $COMPOSE_FILE stop
+    compose stop
     echo "✅ Database services stopped"
     ;;
   
   restart)
     echo "🔄 Restarting database services..."
-    docker-compose -f $COMPOSE_FILE restart
+    compose restart
     echo "✅ Database services restarted"
     ;;
   
   down)
     echo "⚠️  Stopping and removing containers (data preserved)..."
-    docker-compose -f $COMPOSE_FILE down
+    compose down
     echo "✅ Containers removed"
     ;;
   
@@ -42,7 +59,7 @@ case "$1" in
     echo "⚠️  WARNING: This will delete all database data!"
     read -p "Are you sure? (yes/no): " confirm
     if [ "$confirm" == "yes" ]; then
-      docker-compose -f $COMPOSE_FILE down -v
+      compose down -v
       echo "✅ Database destroyed (volumes deleted)"
     else
       echo "❌ Cancelled"
@@ -50,11 +67,11 @@ case "$1" in
     ;;
   
   logs)
-    docker-compose -f $COMPOSE_FILE logs -f
+    compose logs -f
     ;;
   
   status)
-    docker-compose -f $COMPOSE_FILE ps
+    compose ps
     ;;
   
   psql)
@@ -103,7 +120,7 @@ case "$1" in
     echo "🏗️  Setting up database for the first time..."
     echo ""
     echo "1️⃣  Starting database services..."
-    docker-compose -f $COMPOSE_FILE up -d
+    compose up -d
     echo ""
     echo "2️⃣  Waiting for PostgreSQL to be ready..."
     sleep 5


### PR DESCRIPTION
## Summary

Two script changes for smoother deployments across servers with differing Docker setups.

### 1. `db.sh` — detect Docker Compose flavour

`db.sh` hardcoded the legacy `docker-compose` binary, which meant manually editing the script on servers that only ship the v2 `docker compose` plugin. It now detects which is available at startup, routes all invocations through a `compose()` wrapper, and fails with a clear message if neither is present.

Prefers v2, falls back to v1.

### 2. `app.sh` — new PM2 + database lifecycle script

Bringing the stack up previously meant running `db.sh`, `npm run build` and a hand-written `pm2` command in the right order. `app.sh` wraps that into one entry point.

Two modes, selected by an optional second argument (or `MODE` env), defaulting to `prod`:

| mode | command | port | PM2 name |
|---|---|---|---|
| `prod` (default) | `next start` | 3000 | `s3-browser` |
| `dev` | `next dev` | 5000 | `s3-browser-dev` |

Commands: `setup start stop restart build status logs migrate seed reset purge`

- All database work delegates to `db.sh`, so the compose handling stays in one place.
- Guards up front: `db.sh` present and executable, `pm2` installed, `.env` exists before anything starts. Prod builds automatically if `.next` is missing.
- `purge` removes the PM2 process, database containers and volumes, `.next` and `node_modules`, behind a type-`purge`-to-confirm prompt.
- Dev mode invokes `next` via `npx` rather than `npm run dev`, because that script hardcodes `-p 5000` and would otherwise ignore `PORT`. `PORT=8080 ./app.sh start dev` works.

## Testing

- `db.sh` compose detection exercised across all three paths (v2 present, v1 only, neither) using stub binaries.
- `app.sh` PM2 path verified for real: started dev under PM2, confirmed `/login` returned 200, stopped it via the script.
- Docker was unreachable in the dev environment used, so the database-touching paths of `app.sh` were only exercised through stubs. Author reports the scripts working on a real setup.

## Docs

`README.md` and `CLAUDE.md` updated with the new `app.sh` commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)